### PR TITLE
[fix] 편지 전체 컬러 조회 API에 주인 이름 추가

### DIFF
--- a/src/main/java/org/sopt/sopkathon/domain/letter/dto/response/LettersColorResponse.java
+++ b/src/main/java/org/sopt/sopkathon/domain/letter/dto/response/LettersColorResponse.java
@@ -5,10 +5,11 @@ import org.sopt.sopkathon.domain.letter.domain.Color;
 import java.util.List;
 
 public record LettersColorResponse(
+        String name,
         Integer letterCount,
         List<Color> colors
 ) {
-    public static LettersColorResponse of(Integer letterCount, List<Color> colors) {
-        return new LettersColorResponse(letterCount, colors);
+    public static LettersColorResponse of(String name, Integer letterCount, List<Color> colors) {
+        return new LettersColorResponse(name, letterCount, colors);
     }
 }

--- a/src/main/java/org/sopt/sopkathon/domain/letter/service/LetterService.java
+++ b/src/main/java/org/sopt/sopkathon/domain/letter/service/LetterService.java
@@ -33,7 +33,7 @@ public class LetterService {
     public LettersColorResponse getLetterColors(LettersColorRequest request){
         User user = userRepository.findByIdOrThrow(request.userId());
         List<Color> colors = letterRepository.findAllColorsByUser(user);
-        return LettersColorResponse.of(colors.size(), colors);
+        return LettersColorResponse.of(user.getName(), colors.size(), colors);
     }
 
     public LetterDetailResponse getLetter(Long letterId) {


### PR DESCRIPTION
## Related Issue 📌
- close #16 
## Description ✔️
- 편지 전체 컬러 조회 API에 주인 이름 추가
